### PR TITLE
update to getStart() to match current lme4 params

### DIFF
--- a/R/optimization.R
+++ b/R/optimization.R
@@ -22,7 +22,7 @@ optimizeLmerCens <- function(devfun,
 
   opt <- optwrapCens(optimizer,
                      devfun,
-                     lme4:::getStart(start, lower=rho$lower, pred=rho$pp, returnVal = "all"),
+                     lme4:::getStart(start, pred=rho$pp, returnVal = "all"),
                      lower=rho$lower,
                      control=control,
                      verbose=verbose,

--- a/R/optimization.R
+++ b/R/optimization.R
@@ -22,7 +22,7 @@ optimizeLmerCens <- function(devfun,
 
   opt <- optwrapCens(optimizer,
                      devfun,
-                     lme4:::getStart(start,rho$lower,rho$pp, returnVal = "all"),
+                     lme4:::getStart(start, lower=rho$lower, pred=rho$pp, returnVal = "all"),
                      lower=rho$lower,
                      control=control,
                      verbose=verbose,


### PR DESCRIPTION
a recent change to lme4:::getStart function removed the lower= parameter, causing lmercens() to break.